### PR TITLE
Add compatibility with VAE - Australia (Boombat)

### DIFF
--- a/Source/Evaluator.cs
+++ b/Source/Evaluator.cs
@@ -14,7 +14,7 @@ namespace BoomMod
                     { HediffDefOf.Shredded, 1f }
         };
 
-        private static readonly string[] ListedPawnKindDefs = { "Boomalope", "Boomrat" };
+        private static readonly string[] ListedPawnKindDefs = { "Boomalope", "Boomrat", "AEXP_Boombat" };
 
         private static bool _explosionImminent;
 


### PR DESCRIPTION
From Vanilla Animals Expanded - Australia `1.1/Defs/ThingDefs_Races/Races_Expanded_Australia.xml`:
```
	<ThingDef ParentName="AnimalThingBase">
		<defName>AEXP_Boombat</defName>
		<label>boombat</label>
		<description>Due to some insane experiment, these cute, fluffy rodents create a powerful fire-starting explosion when killed.</description>
```
```
		<race>
			<herdAnimal>true</herdAnimal>
			<deathActionWorkerClass>DeathActionWorker_SmallExplosion</deathActionWorkerClass>
```

If I understand how this mod works, simply adding the defName to the list should allow it to work without causing additional bugs.